### PR TITLE
Solicitar login con Puter y guardar datos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+## Lietweet
+
+Esta pequeña aplicación genera una vista previa de un tweet.
+
+### Puter.js
+
+Se utiliza [Puter.js](https://puter.com) para guardar la foto de perfil y el nombre a mostrar del usuario.
+Al cargar la página se solicita iniciar sesión y se recuperan estos datos desde `puter.kv`.
+Si ya existe una foto de perfil o nombre guardados, el formulario es más corto y aparecen botones en la esquina superior izquierda para reemplazarlos cuando se desee.
+La configuración avanzada permite desactivar el ícono de verificación.
+Las modificaciones se guardan de nuevo mediante `puter.kv`.

--- a/css/main.css
+++ b/css/main.css
@@ -99,6 +99,43 @@ body.dark-theme .back-btn:hover {
     background-color: #0c1822; /* Un azul muy oscuro para hover en tema oscuro */
 }
 
+.settings-buttons {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.settings-btn {
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: bold;
+    color: #1DA1F2;
+    background-color: #ffffff;
+    border: 1px solid #e1e8ed;
+    border-radius: 999px;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    transition: background-color 0.2s;
+}
+
+.settings-btn:hover {
+    background-color: #e8f5fe;
+}
+
+body.dark-theme .settings-btn {
+    background-color: #1a1a1a;
+    color: #1DA1F2;
+    border-color: #383838;
+    box-shadow: 0 2px 8px rgba(255,255,255,0.1);
+}
+
+body.dark-theme .settings-btn:hover {
+    background-color: #0c1822;
+}
+
 .form-container {
     padding: 25px;
     border-radius: 12px;

--- a/index.html
+++ b/index.html
@@ -4,21 +4,33 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Generador de Tweets</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="css/main.css">
+    <script src="https://js.puter.com/v2/"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 <body class="light-theme">
     
     <button id="back-to-form-btn" class="back-btn">← Editar</button>
+    <div class="settings-buttons">
+        <button id="change-profile-pic-btn" class="settings-btn" style="display:none;">Foto de perfil</button>
+        <button id="change-display-name-btn" class="settings-btn" style="display:none;">Nombre</button>
+        <button id="change-username-btn" class="settings-btn" style="display:none;">Usuario</button>
+    </div>
 
     <div class="form-container" id="form-container">
         <h1>Crea tu Tweet</h1>
         <form id="tweet-form">
+            <label for="display-name">Nombre a mostrar:</label>
+            <input type="text" id="display-name" placeholder="Ej. Juan Pérez" required>
+
             <label for="username">Usuario (sin @):</label>
-            <input type="text" id="username" value="Gatito Sentimental" required>
+            <input type="text" id="username" placeholder="usuario" required>
             
             <label for="tweet-text">Texto del Tweet:</label>
             <textarea id="tweet-text" rows="4" required></textarea>
+
+            <label for="profile-image-upload">Foto de perfil:</label>
+            <input type="file" id="profile-image-upload" accept="image/*">
 
             <label for="optional-image-upload">Subir imagen (opcional):</label>
             <input type="file" id="optional-image-upload" accept="image/*">
@@ -48,13 +60,18 @@
                 <option value="light">Claro</option>
                 <option value="dark">Oscuro</option>
             </select>
-            
+
+            <button type="button" id="advanced-btn">Configuración avanzada</button>
+            <div id="advanced-settings" style="display:none;">
+                <label><input type="checkbox" id="include-check" checked> Incluir ícono de verificación</label>
+            </div>
+
             <button type="submit">Generar Tweet</button>
         </form>
     </div>
 
     <div class="tweet-card" id="tweet-card"></div>
 
-    <script src="main.js"></script>
+    <script src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prompt sign in to Puter on page load
- store avatar, display name and username with `puter.kv`
- hide profile and name fields once saved and show edit buttons in top left
- add advanced settings with verification toggle
- document new Puter logic and configuration

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850d5e4771083268fd9f822fc956374